### PR TITLE
Show driver value with purple background

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -224,8 +224,7 @@ class MESH_UL_shape_keys_plus(bpy.types.UIList):
                 buttons.prop(
                     data=item,
                     property='frame',
-                    text="",
-                    emboss=False)
+                    text="")
             elif index > 0:
                 vrow = buttons.row()
                 vrow.active = not selections or selections and selected
@@ -233,8 +232,7 @@ class MESH_UL_shape_keys_plus(bpy.types.UIList):
                 vrow.prop(
                     data=item,
                     property='value',
-                    text="",
-                    emboss=False)
+                    text="")
             
             buttons.prop(
                 data=item,


### PR DESCRIPTION
Hello Montague:

Thank you for this awesome addon! I noticed that the values with driver are shown without background. I'm not sure if it's intentional, but I think it's clearer to just show it with purple background like default. 

Plus the screenshot on README has purple background too:

https://github.com/MichaelGlenMontague/shape_keys_plus/blob/master/screenshot.png